### PR TITLE
10.0 default stock location from project view

### DIFF
--- a/stock_location_analytic_account/__manifest__.py
+++ b/stock_location_analytic_account/__manifest__.py
@@ -22,7 +22,7 @@
 {
     'name': 'Analytic account - Stock location relation',
     'summary': 'Integrate stock location with analytic account',
-    'version': '10.0.1.3.2',
+    'version': '10.0.1.3.3',
     'category': 'Inventory',
     'website': 'http://www.tawasta.fi',
     'author': 'Oy Tawasta Technologies Ltd.',

--- a/stock_location_analytic_account/i18n/fi.po
+++ b/stock_location_analytic_account/i18n/fi.po
@@ -1,44 +1,64 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* stock_location_project
+#	* stock_location_analytic_account
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-01-09 13:11+0000\n"
-"PO-Revision-Date: 2018-01-09 15:12+0200\n"
+"POT-Creation-Date: 2018-05-02 10:33+0000\n"
+"PO-Revision-Date: 2018-05-02 10:33+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-"Language: fi\n"
-"X-Generator: Poedit 1.8.7.1\n"
 
-#. module: stock_location_project
-#: model:ir.model.fields,help:stock_location_project.field_stock_location_project_id
-msgid "Belongs to a project"
-msgstr "Kuuluu projektille"
+#. module: stock_location_analytic_account
+#: model:ir.model,name:stock_location_analytic_account.model_account_analytic_account
+msgid "Analytic Account"
+msgstr "Kustannuspaikka"
 
-#. module: stock_location_project
-#: model:ir.ui.view,arch_db:stock_location_project.edit_project
+#. module: stock_location_analytic_account
+#: model:ir.model.fields,field_description:stock_location_analytic_account.field_stock_location_analytic_account_id
+msgid "Analytic account"
+msgstr "Kustannuspaikka"
+
+#. module: stock_location_analytic_account
+#: model:ir.model.fields,help:stock_location_analytic_account.field_stock_location_analytic_account_id
+msgid "Belongs to an analytic account"
+msgstr "Kuuluu kustannuspaikalle"
+
+#. module: stock_location_analytic_account
+#: model:ir.model.fields,field_description:stock_location_analytic_account.field_account_analytic_account_default_location_id
+#: model:ir.model.fields,field_description:stock_location_analytic_account.field_project_project_default_location_id
+msgid "Default location"
+msgstr "Oletusvarastopaikka"
+
+#. module: stock_location_analytic_account
+#: model:ir.ui.view,arch_db:stock_location_analytic_account.edit_project
 msgid "Inventory"
 msgstr "Varasto"
 
-#. module: stock_location_project
-#: model:ir.model,name:stock_location_project.model_stock_location
+#. module: stock_location_analytic_account
+#: model:ir.model,name:stock_location_analytic_account.model_stock_location
 msgid "Inventory Locations"
 msgstr "Varastopaikat"
 
-#. module: stock_location_project
-#: model:ir.model,name:stock_location_project.model_project_project
-#: model:ir.model.fields,field_description:stock_location_project.field_stock_location_project_id
-msgid "Project"
-msgstr "Projektit"
-
-#. module: stock_location_project
-#: model:ir.model.fields,field_description:stock_location_project.field_project_project_location_ids
-msgid "Stock locations"
+#. module: stock_location_analytic_account
+#: model:ir.model.fields,field_description:stock_location_analytic_account.field_account_analytic_account_location_ids
+#: model:ir.model.fields,field_description:stock_location_analytic_account.field_project_project_location_ids
+msgid "Inventory locations"
 msgstr "Varastopaikat"
+
+#. module: stock_location_analytic_account
+#: code:addons/stock_location_analytic_account/models/analytic_account.py:55
+#, python-format
+msgid "Please use a location in the inventory locations."
+msgstr "Ole hyvä ja käytä yhtä Varastopaikat-kentän paikoista."
+
+#. module: stock_location_analytic_account
+#: model:ir.model,name:stock_location_analytic_account.model_project_project
+msgid "Project"
+msgstr "Projekti"

--- a/stock_location_analytic_account/models/__init__.py
+++ b/stock_location_analytic_account/models/__init__.py
@@ -1,2 +1,3 @@
 from . import analytic_account
+from . import project_project
 from . import stock_location

--- a/stock_location_analytic_account/models/project_project.py
+++ b/stock_location_analytic_account/models/project_project.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo import models, api
+
+
+class ProjectProject(models.Model):
+
+    _inherit = 'project.project'
+
+    @api.onchange('location_ids')
+    @api.depends('location_ids')
+    def _default_get_default_location(self):
+        for record in self:
+            if record.location_ids and not record.default_location_id:
+                record.default_location_id = record.location_ids[0]

--- a/stock_location_analytic_account/views/project_project.xml
+++ b/stock_location_analytic_account/views/project_project.xml
@@ -10,6 +10,8 @@
 			<group name="misc" position="before">
                 <group string="Inventory" name="inventory">
                     <field name="location_ids" widget="many2many_tags"/>
+					<field name="default_location_id"
+						   attrs="{'required': [('location_ids', '!=', [])]}" />
                 </group>
 			</group>
 


### PR DESCRIPTION
Add the possibility to set the default stock location also from the Project main form view (Project --> [project X] --> Settings). Previously this was possible only from the Analytic Account form view (Accounting --> Configuration --> Analytic Accounts --> [project X])